### PR TITLE
Add license function

### DIFF
--- a/src/components/plugin-store/PluginCard.vue
+++ b/src/components/plugin-store/PluginCard.vue
@@ -30,7 +30,7 @@
     </div>
     <div class="card-content">
       <div class="plugin-dependencies">
-        <h4><i-mdi-puzzle-outline class="icon"></i-mdi-puzzle-outline> 依赖项</h4>
+        <h4><i-mdi-puzzle-outline class="icon"></i-mdi-puzzle-outline> 依赖插件</h4>
         <ul>
           <template v-if="plugin.dependencies && plugin.dependencies.length > 0">
             <li v-for="dep in plugin.dependencies" :key="dep" :class="{ 'missing': !isPluginExist(dep) }">
@@ -68,7 +68,7 @@
         </span>
       </div>
     </div>
-    
+
     <div class="plugin-meta">
       <div class="plugin-author">
         <span><i-mdi-account class="icon"></i-mdi-account> 作者:</span>
@@ -81,8 +81,8 @@
 
       <div class="plugin-license">
         <span><i-mdi-license class="icon"></i-mdi-license> 许可证:</span>
-        <a v-if="plugin.license?.type" :href="plugin.license.link" target="_blank">{{ plugin.license.type }}</a>
-        <span v-else>未指定</span>
+        <a v-if="plugin.license?.type" :href="plugin.license.link" target="_blank" class="license-link">{{ plugin.license.type }}</a>
+        <span v-else class="license-unspecified">未指定</span>
       </div>
     </div>
   </div>
@@ -614,7 +614,8 @@ function resetCard(event: MouseEvent) {
 }
 
 .plugin-author a::after,
-.plugin-license a::after {
+.plugin-license a::after,
+.license-link::after {
   content: '';
   position: absolute;
   width: 0;
@@ -626,8 +627,16 @@ function resetCard(event: MouseEvent) {
 }
 
 .plugin-author a:hover::after,
-.plugin-license a:hover::after {
+.plugin-license a:hover::after,
+.license-link:hover::after {
   width: 100%;
+}
+
+.license-unspecified {
+  color: #888;
+  font-size: 0.85rem;
+  position: relative;
+  z-index: 1;
 }
 
 :deep(.highlight-text) {

--- a/src/services/api.ts
+++ b/src/services/api.ts
@@ -32,6 +32,7 @@ export interface ApiPlugin {
   funcs: ApiPluginFunction[]
   configs: ApiPluginConfig[]
   repository: string
+  license?: string
 }
 
 export interface ApiResponse {

--- a/src/services/converter.ts
+++ b/src/services/converter.ts
@@ -1,6 +1,6 @@
 import type { Plugin, Author, License } from '../types/plugin'
 import { licenseLinks } from '../types/plugin'
-import type { ApiResponse } from './api'
+import type { ApiResponse, ApiPlugin } from './api'
 
 /**
  * 将API返回的插件数据转换为应用内的Plugin类型
@@ -27,8 +27,19 @@ export function convertApiPluginsToAppPlugins(apiResponse: ApiResponse): Plugin[
     }
 
     // 处理许可证信息
-    const license: License | null = null
-    // 如果将来API提供了许可证信息，可以在这里处理
+    let license: License | null = null;
+    
+    // 处理API插件中的许可证信息
+    if (apiPlugin.license) {
+      const licenseType = apiPlugin.license;
+      // 查找预定义的许可证链接
+      const predefinedLink = licenseLinks[licenseType as keyof typeof licenseLinks];
+      
+      license = {
+        type: licenseType,
+        link: predefinedLink || `https://opensource.org/licenses/${encodeURIComponent(licenseType)}`
+      };
+    }
 
     // 创建Plugin对象
     const plugin: Plugin = {


### PR DESCRIPTION
Add license parsing
When the JSON file is written in this way, the license can be parsed correctly on the front end

```
    "ModelChat": {
      "name": "ModelChat",
      "versions": [
        "1.0.0"
      ],
      "latest_version": "1.0.0",
      "description": "大模型聊天插件，支持本地大模型、云端大模型、图像识别",
      "author": "Magneto",
      "plugin_dependencies": {},
      "tags": [],
      "homepage": "",
      "funcs": [],
      "configs": [],
      "license": "MIT",
      "repository": "https://github.com/ouyangyanhuo/ModelChat"
    }
  },
```